### PR TITLE
Fixes to naomi-setup.py

### DIFF
--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -3,24 +3,25 @@
 #########################################
 # Installing python and necessary packages
 # for Naomi. This script will install python
-# into the ~/local/bin directory and install
-# naomi & requirements in their respective
-# directories.
+# into the ~/.naomi/local/bin directory and
+# install naomi & requirements in their
+# respective directories.
 #########################################
 # Assume this program is in the main Naomi directory
 # so we can save and return to it.
 export NAOMI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo "NAOMI_DIR = $NAOMI_DIR"
+echo "Updating apt, preparing to install libssl-dev, gettext, portaudio19-dev and libasound2-dev"
 # install dependencies
 sudo apt-get update
-# libssl1.0-dev required to get the python _ssl module working
-sudo apt-get install libssl-dev portaudio19-dev libasound2-dev -y
+# libssl-dev required to get the python _ssl module working
+sudo apt-get install libssl-dev gettext portaudio19-dev libasound2-dev -y
 
 # installing python 2.7.13
 echo 'Installing python 2.7.13 to ~/.naomi/local'
 mkdir -p ~/.naomi/local
 cd ~/.naomi/local
-wget http://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
+wget https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
 tar xvzf Python-2.7.13.tgz
 cd Python-2.7.13
 ./configure
@@ -28,13 +29,15 @@ make
 make altinstall prefix=~/.naomi/local  # specify local installation directory
 ln -s ~/.naomi/local/bin/python2.7 ~/.naomi/local/bin/python
 cd ..  # ~/.naomi/local
+
 # install setuptools and pip for package management
 echo 'Installing setuptools'
-wget http://pypi.python.org/packages/source/s/setuptools/setuptools-0.6c11.tar.gz#md5=7df2a529a074f613b509fb44feefe74e
+wget https://pypi.python.org/packages/source/s/setuptools/setuptools-0.6c11.tar.gz#md5=7df2a529a074f613b509fb44feefe74e
 tar xvzf setuptools-0.6c11.tar.gz
 cd setuptools-0.6c11 # ~/.naomi/local/setuptools-0.6c11
 ~/.naomi/local/bin/python setup.py install  # specify the path to the python you installed above
 cd .. # ~/.naomi/local
+
 # The old version of pip expects to access pypi.org using http. PyPi now
 # requires ssl for all connections.
 wget https://files.pythonhosted.org/packages/45/ae/8a0ad77defb7cc903f09e551d88b443304a9bd6e6f124e75c0fbbf6de8f7/pip-18.1.tar.gz
@@ -52,5 +55,6 @@ cd $NAOMI_DIR
 echo "#!/bin/bash" > Naomi
 echo "~/.naomi/local/bin/python $NAOMI_DIR/Naomi.py $@" >> Naomi
 chmod a+x Naomi
-./Naomi
+echo "In the future, run $NAOMI_DIR/Naomi to start Naomi"
+./Naomi --repopulate
 

--- a/naomi-setup.sh
+++ b/naomi-setup.sh
@@ -7,38 +7,50 @@
 # naomi & requirements in their respective
 # directories.
 #########################################
+# Assume this program is in the main Naomi directory
+# so we can save and return to it.
+export NAOMI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd )"
+echo "NAOMI_DIR = $NAOMI_DIR"
+# install dependencies
+sudo apt-get update
+# libssl1.0-dev required to get the python _ssl module working
+sudo apt-get install libssl-dev portaudio19-dev libasound2-dev -y
 
-# installing python 2.7.3
-mkdir -p ~/local
-wget http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
-tar xvzf Python-2.7.3.tgz
-cd Python-2.7.3
+# installing python 2.7.13
+echo 'Installing python 2.7.13 to ~/.naomi/local'
+mkdir -p ~/.naomi/local
+cd ~/.naomi/local
+wget http://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
+tar xvzf Python-2.7.13.tgz
+cd Python-2.7.13
 ./configure
 make
-make altinstall prefix=~/local  # specify local installation directory
-ln -s ~/local/bin/python2.7 ~/local/bin/python
-cd ..
-
+make altinstall prefix=~/.naomi/local  # specify local installation directory
+ln -s ~/.naomi/local/bin/python2.7 ~/.naomi/local/bin/python
+cd ..  # ~/.naomi/local
 # install setuptools and pip for package management
+echo 'Installing setuptools'
 wget http://pypi.python.org/packages/source/s/setuptools/setuptools-0.6c11.tar.gz#md5=7df2a529a074f613b509fb44feefe74e
 tar xvzf setuptools-0.6c11.tar.gz
-cd setuptools-0.6c11
-~/local/bin/python setup.py install  # specify the path to the python you installed above
-cd ..
-wget http://pypi.python.org/packages/source/p/pip/pip-1.2.1.tar.gz#md5=db8a6d8a4564d3dc7f337ebed67b1a85
-tar xvzf pip-1.2.1.tar.gz
-cd pip-1.2.1
-~/local/bin/python setup.py install  # specify the path to the python you installed above
-
-# install framework
-cd ~
-apt-get update
-apt-get install portaudio19-dev libasound2-dev -y
+cd setuptools-0.6c11 # ~/.naomi/local/setuptools-0.6c11
+~/.naomi/local/bin/python setup.py install  # specify the path to the python you installed above
+cd .. # ~/.naomi/local
+# The old version of pip expects to access pypi.org using http. PyPi now
+# requires ssl for all connections.
+wget https://files.pythonhosted.org/packages/45/ae/8a0ad77defb7cc903f09e551d88b443304a9bd6e6f124e75c0fbbf6de8f7/pip-18.1.tar.gz
+tar xvzf pip-18.1.tar.gz
+cd pip-18.1 # ~/.naomi/local/pip-18.1
+~/.naomi/local/bin/python setup.py install  # specify the path to the python you installed above
 
 # install naomi & dependancies
-~/Naomi/pip install -r python_requirements.txt
-
+echo "Returning to $NAOMI_DIR"
+cd $NAOMI_DIR
+~/.naomi/local/bin/pip install -r python_requirements.txt
+./compile_translations.sh
 
 # start the naomi setup process
-cd Naomi
-python Populate.py
+echo "#!/bin/bash" > Naomi
+echo "~/.naomi/local/bin/python $NAOMI_DIR/Naomi.py $@" >> Naomi
+chmod a+x Naomi
+./Naomi
+


### PR DESCRIPTION
The naomi-setup.py script installs its own version of python
locally under user permissions.

The version of pip was old and attempting to download package
files without using ssl, which appears to no longer be supported
by PyPi.org, so uusing it to process python-requirements.txt was
just failing. I updated that, then I was getting error messages
about failing to build the _ssl module when building python, so
was still unable to download packages from pypi.org. Moved the
apt installs to before installing python and installed the
libssl1.0-dev. Upgraded python from 2.7.3 to 2.7.13.

Saved the directory that the naomi-setup.sh file lives in since
that should be the location of the Naomi install. Return to
that directory after installing python, pip, etc. and don't just
assume the directory is called ~/Naomi.

After returning, you need to run Naomi using the copy of python
you just installed. You have three choices there. Ensure that
/usr/bin/env always finds your python2 first, change the crunch
bang line in Naomi.py, or create a shell script that calls
Naomi.py with the correct version of python. I went for option
three.
